### PR TITLE
use detectEquilibration to determine length of production

### DIFF
--- a/trustbutverify/mixture_system.py
+++ b/trustbutverify/mixture_system.py
@@ -24,7 +24,7 @@ N_STEPS_MIXTURES = 500000 # 1 ns (at a time)
 N_EQUIL_STEPS_MIXTURES = 5000000 # 5ns
 OUTPUT_FREQUENCY_MIXTURES = 5000 # 10ps
 OUTPUT_DATA_FREQUENCY_MIXTURES = 125 # 0.25ps
-STD_ERROR_TOLERANCE = 0.1 # g/mL
+STD_ERROR_TOLERANCE = 0.0001 # g/mL
 
 class MixtureSystem(System):
     def __init__(self, cas_strings, n_monomers, temperature, pressure=PRESSURE, output_frequency=OUTPUT_FREQUENCY_MIXTURES, output_data_frequency=OUTPUT_DATA_FREQUENCY_MIXTURES, n_steps=N_STEPS_MIXTURES, equil_output_frequency=OUTPUT_FREQUENCY_MIXTURES, stderr_tolerance = STD_ERROR_TOLERANCE, **kwargs):


### PR DESCRIPTION
Further addresses discussion from https://github.com/choderalab/TrustButVerify/issues/7#issuecomment-55505375

Primary changes:
- production() runs 1ns at a time, and uses timeseries.detectEquilibration() to determine whether the simulation has converged to within a predefined (0.0001 g/mL) standard error.
- equilibrate() is an optional fixed-length equilibration step.  If run, this is in addition to (not instead of) timeseries.detectEquilibration() checking for convergence.
